### PR TITLE
XSOM fails when using entity resolver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 *.bat text eol=crlf
 *.sh text eol=lf
+
+*.jar binary
+*.vsd binary
+*.sxd binary

--- a/jaxb-ri/external/rngom/src/main/resources/META-INF/MANIFEST.MF
+++ b/jaxb-ri/external/rngom/src/main/resources/META-INF/MANIFEST.MF
@@ -3,4 +3,3 @@ Built-By: snajper
 Build-Jdk: 1.7.0_25
 Created-By: Apache Maven
 Archiver-Version: Plexus Archiver
-

--- a/jaxb-ri/xsom/pom.xml
+++ b/jaxb-ri/xsom/pom.xml
@@ -103,6 +103,12 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.10.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/impl/parser/NGCCRuntimeEx.java
+++ b/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/impl/parser/NGCCRuntimeEx.java
@@ -107,10 +107,9 @@ public class NGCCRuntimeEx extends NGCCRuntime implements PatcherManager {
     public boolean chameleonMode = false;
 
     /**
-     * URI that identifies the schema document.
-     * Maybe null if the system ID is not available.
+     * The document InputSource that us processed for the schema document.
      */
-    private String documentSystemId;
+    private InputSource documentSource;
 
     /**
      * Keep the local name of elements encountered so far.
@@ -131,7 +130,7 @@ public class NGCCRuntimeEx extends NGCCRuntime implements PatcherManager {
      */
     public SchemaDocumentImpl document;
 
-    NGCCRuntimeEx( ParserContext _parser ) {
+    public NGCCRuntimeEx( ParserContext _parser ) {
         this(_parser,false,null);
     }
 
@@ -197,50 +196,94 @@ public class NGCCRuntimeEx extends NGCCRuntime implements PatcherManager {
      *      Otherwise it returns null, in which case import/include should be abandoned.
      */
     private InputSource resolveRelativeURL( String namespaceURI, String relativeUri ) throws SAXException {
-        try {
-            String baseUri = getLocator().getSystemId();
-            if(baseUri==null)
-                // if the base URI is not available, the document system ID is
-                // better than nothing.
-                baseUri=documentSystemId;
 
-            EntityResolver er = parser.getEntityResolver();
+        try {
+
+            // if it is a xsd:import with namespace attribute only, it is a publicId lookup
+            if (namespaceURI != null && relativeUri == null) {
+                InputSource source = tryResolveResource(namespaceURI);
+                if (source != null) {
+                    source.setPublicId(namespaceURI);
+                    return source;
+                }
+            }
+
+            // try relativeURI as a publicId lookup, it's totally up to the entity resolver to give us a valid source
+            InputSource source = tryResolveResource(relativeUri);
+            if (source != null) {
+                source.setPublicId(relativeUri);
+                return source;
+            }
+
+            // now we continue as normal to interact with the entity resolver
+            source = tryResolveResource(namespaceURI, relativeUri);
+            if (source != null) {
+                return source;
+            }
+
+            // do the original dark magic
+
+            String baseUri = getLocator().getSystemId();
+
+
+            // if the base URI is not available, the document systemId is better than nothing.
+            if (baseUri == null)
+                baseUri = documentSource.getSystemId();
+
             String systemId = null;
 
-            if (relativeUri!=null) {
+            if (relativeUri != null) {
                 if (isAbsolute(relativeUri)) {
-                    systemId = relativeUri;
+                    systemId = relativeUri; // <- FIXME this assignment is never used as in the original code
                 }
                 if (baseUri == null || !isAbsolute(baseUri)) {
                     throw new IOException("Unable to resolve relative URI " + relativeUri + " because base URI is not absolute: " + baseUri);
                 }
                 systemId = new URL(new URL(baseUri), relativeUri).toString();
+
+                source = tryResolveResource(namespaceURI, systemId);
+
+                if (source != null) {
+                    return source;
+                }
+
+                String normalizedSystemId = URI.create(systemId).normalize().toASCIIString();
+                source = tryResolveResource(namespaceURI, normalizedSystemId);
+
+                if (source != null) {
+                    return source;
+                }
+
+                if (systemId != null)
+                    return new InputSource(systemId);
+
             }
 
-            if (er!=null) {
-                InputSource is = er.resolveEntity(namespaceURI,systemId);
-                if (is == null) {
-                    try {
-                        String normalizedSystemId = URI.create(systemId).normalize().toASCIIString();
-                        is = er.resolveEntity(namespaceURI,normalizedSystemId);
-                    } catch (Exception e) {
-                        // just ignore, this is a second try, return the fallback if this breaks
-                    }
-                }
-                if (is != null) {
-                    return is;
-                }
-            }
+            return null;
 
-            if (systemId!=null)
-                return new InputSource(systemId);
-            else
-                return null;
         } catch (IOException e) {
-            SAXParseException se = new SAXParseException(e.getMessage(),getLocator(),e);
+            SAXParseException se = new SAXParseException(e.getMessage(), getLocator(), e);
             parser.errorHandler.error(se);
             return null;
         }
+
+    }
+
+
+    private InputSource tryResolveResource(String publicId) throws SAXException {
+        return tryResolveResource(publicId, null);
+    }
+
+    private InputSource tryResolveResource(String publicId, String systemId) throws SAXException {
+        try {
+            if (parser.getEntityResolver() != null) {
+                return parser.getEntityResolver().resolveEntity(publicId, systemId);
+            }
+        } catch (IOException e) {
+            SAXParseException se = new SAXParseException(e.getMessage(), getLocator(), e);
+            parser.errorHandler.warning(se);
+        }
+        return null;
     }
 
     private static final Pattern P = Pattern.compile(".*[/#?].*");
@@ -324,39 +367,44 @@ public class NGCCRuntimeEx extends NGCCRuntime implements PatcherManager {
      *      needs to be skipped.
      */
     public boolean hasAlreadyBeenRead() {
-        if( documentSystemId!=null ) {
-            if( documentSystemId.startsWith("file:///") )
-                // change file:///abc to file:/abc
-                // JDK File.toURL method produces the latter, but according to RFC
-                // I don't think that's a valid URL. Since two different ways of
-                // producing URLs could produce those two different forms,
-                // we need to canonicalize one to the other.
-                documentSystemId = "file:/"+documentSystemId.substring(8);
+
+        assert document == null : "schema document has already been set, internal implementation issue";
+
+        String id = null;
+        if (documentSource.getSystemId() != null) {
+            id = documentSource.getSystemId();
+        } else if (documentSource.getPublicId() != null) {
+            id = documentSource.getPublicId();
         } else {
-            // if the system Id is not provided, we can't test the identity,
-            // so we have no choice but to read it.
-            // the newly created SchemaDocumentImpl will be unique one
+            // FIXME we really should be blowing up here due to the use of some random InputSource that can't be bothered to supply a document id
         }
 
-        assert document ==null;
-        document = new SchemaDocumentImpl( currentSchema, documentSystemId );
-
-        SchemaDocumentImpl existing = parser.parsedDocuments.get(document);
-        if(existing==null) {
-            parser.parsedDocuments.put(document,document);
+        // referrer namespace not the current if in chameleon mode
+        String namespace;
+        if(chameleonMode) {
+            namespace = referer.currentSchema.getTargetNamespace();
         } else {
-            document = existing;
+            namespace = currentSchema.getTargetNamespace();
         }
 
-        assert document !=null;
+        boolean alreadyRead = parser.hasAlreadyBeenRead(namespace, id);
+        if (alreadyRead) {
+            document = parser.getSchemaDocument(namespace, id);
+        } else {
+            document = new SchemaDocumentImpl(currentSchema, id);
+            parser.addSchemaDocument(namespace, document);
+        }
 
-        if(referer!=null) {
-            assert referer.document !=null : "referer "+referer.documentSystemId+" has docIdentity==null";
+        assert document != null : "schema document was not created";
+
+        if (referer != null) {
+            assert referer.document != null : "referer " + referer.documentSource.getSystemId() + " has docIdentity==null";
             referer.document.references.add(this.document);
             this.document.referers.add(referer.document);
         }
 
-        return existing!=null;
+        return alreadyRead;
+
     }
 
     /**
@@ -373,7 +421,7 @@ public class NGCCRuntimeEx extends NGCCRuntime implements PatcherManager {
     public void parseEntity( InputSource source, boolean includeMode, String expectedNamespace, Locator importLocation )
             throws SAXException {
 
-        documentSystemId = source.getSystemId();
+        documentSource = source;
         try {
             Schema s = new Schema(this,includeMode,expectedNamespace);
             setRootHandler(s);

--- a/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/impl/parser/NGCCRuntimeEx.java
+++ b/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/impl/parser/NGCCRuntimeEx.java
@@ -222,8 +222,9 @@ public class NGCCRuntimeEx extends NGCCRuntime implements PatcherManager {
             }
 
             // do the original dark magic
-
-            String baseUri = getLocator().getSystemId();
+            String baseUri = null;
+            if(getLocator() != null)
+                baseUri = getLocator().getSystemId();
 
 
             // if the base URI is not available, the document systemId is better than nothing.

--- a/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/impl/parser/ParserContext.java
+++ b/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/impl/parser/ParserContext.java
@@ -45,6 +45,7 @@ import com.sun.xml.xsom.impl.ElementDecl;
 import com.sun.xml.xsom.impl.SchemaImpl;
 import com.sun.xml.xsom.impl.SchemaSetImpl;
 import com.sun.xml.xsom.parser.AnnotationParserFactory;
+import com.sun.xml.xsom.parser.SchemaDocument;
 import com.sun.xml.xsom.parser.XMLParser;
 import com.sun.xml.xsom.parser.XSOMParser;
 import org.xml.sax.EntityResolver;
@@ -56,19 +57,16 @@ import org.xml.sax.SAXParseException;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Vector;
+import java.util.*;
 
 /**
  * Provides context information to be used by {@link NGCCRuntimeEx}s.
- * 
+ *
  * <p>
  * This class does the actual processing for {@link XSOMParser},
  * but to hide the details from the public API, this class in
  * a different package.
- * 
+ *
  * @author Kohsuke Kawaguchi (kohsuke.kawaguchi@sun.com)
  */
 public class ParserContext {
@@ -90,7 +88,7 @@ public class ParserContext {
      *
      * The actual data structure is map from the canonical format [targetNamespace]|[docuemntId] to the parsed schema.
      */
-    private final Map<String, SchemaDocumentImpl> parsedDocuments = new HashMap<String, SchemaDocumentImpl>();
+    private final Map<ParsedKey, SchemaDocumentImpl> parsedDocuments = new HashMap<ParsedKey, SchemaDocumentImpl>();
 
 
     public ParserContext( XSOMParser owner, XMLParser parser ) {
@@ -129,18 +127,19 @@ public class ParserContext {
     }
 
     public boolean hasAlreadyBeenRead(String targetNamespace, String documentId) {
-        return parsedDocuments.containsKey(targetNamespace + '|' + documentId);
+        return parsedDocuments.containsKey(new ParsedKey(targetNamespace, documentId));
     }
 
-    public Map<String, SchemaDocumentImpl> getSchemaDocuments() {
-        return parsedDocuments;
-    }
-    public SchemaDocumentImpl getSchemaDocument(String targetNamespace, String documentId) {
-        return parsedDocuments.get(targetNamespace + '|' + documentId);
+    public Set<SchemaDocument> getSchemaDocuments() {
+        return Collections.unmodifiableSet(new HashSet<SchemaDocument>(parsedDocuments.values()));
     }
 
-    public void addSchemaDocument(String targetNamespace, SchemaDocumentImpl document) {
-        parsedDocuments.put(targetNamespace + '|' + document.getSystemId(), document);
+    SchemaDocumentImpl getSchemaDocument(String targetNamespace, String documentId) {
+        return parsedDocuments.get(new ParsedKey(targetNamespace, documentId));
+    }
+
+    void addSchemaDocument(String targetNamespace, SchemaDocumentImpl document) {
+        parsedDocuments.put(new ParsedKey(targetNamespace, document.getSystemId()), document);
     }
 
     public XSSchemaSet getResult() throws SAXException {
@@ -233,4 +232,40 @@ public class ParserContext {
             setErrorFlag();
         }
     };
+
+    private final class ParsedKey {
+
+        private String namespace;
+
+        private String documentId;
+
+        public ParsedKey(String namespace, String documentId) {
+            this.namespace = namespace;
+            this.documentId = documentId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof ParsedKey)) return false;
+            ParsedKey that = (ParsedKey) o;
+            return Objects.equals(namespace, that.namespace) &&
+                    Objects.equals(documentId, that.documentId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(namespace, documentId);
+        }
+
+        @Override
+        public String toString() {
+            final StringBuffer sb = new StringBuffer("Key {")
+                    .append(" namespace [ ").append(namespace).append(" ]")
+                    .append(", documentId [ ").append(documentId).append(" ] }");
+            return sb.toString();
+        }
+
+    }
+
 }

--- a/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/parser/XSOMParser.java
+++ b/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/parser/XSOMParser.java
@@ -222,7 +222,7 @@ public final class XSOMParser {
      *      can be empty but never null.
      */
     public Set<SchemaDocument> getDocuments() {
-        return new HashSet<SchemaDocument>(context.getSchemaDocuments().values());
+        return context.getSchemaDocuments();
     }
     
     public EntityResolver getEntityResolver() {

--- a/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/parser/XSOMParser.java
+++ b/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/parser/XSOMParser.java
@@ -192,7 +192,7 @@ public final class XSOMParser {
      * For example, one can feed XML Schema inside a WSDL document.
      */
     public ContentHandler getParserHandler() {
-        NGCCRuntimeEx runtime = context.newNGCCRuntime();
+        NGCCRuntimeEx runtime = new NGCCRuntimeEx(context);
         Schema s = new Schema(runtime,false,null);
         runtime.setRootHandler(s);
         return runtime;
@@ -222,7 +222,7 @@ public final class XSOMParser {
      *      can be empty but never null.
      */
     public Set<SchemaDocument> getDocuments() {
-        return new HashSet<SchemaDocument>(context.parsedDocuments.keySet());
+        return new HashSet<SchemaDocument>(context.getSchemaDocuments().values());
     }
     
     public EntityResolver getEntityResolver() {

--- a/jaxb-ri/xsom/src/test/java/com/sun/xml/xsom/parser/InputSourceMockAnswer.java
+++ b/jaxb-ri/xsom/src/test/java/com/sun/xml/xsom/parser/InputSourceMockAnswer.java
@@ -1,0 +1,84 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package com.sun.xml.xsom.parser;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.xml.sax.InputSource;
+
+import java.net.URL;
+import java.util.logging.Logger;
+
+public class InputSourceMockAnswer implements Answer<InputSource> {
+
+    private Logger log = Logger.getLogger(getClass().getName());
+
+    private URL answerWith;
+
+    private String publicId;
+
+    public InputSourceMockAnswer() {
+    }
+
+    public InputSourceMockAnswer(URL answerWith) {
+        this.answerWith = answerWith;
+    }
+
+    public InputSourceMockAnswer(String publicId, URL answerWith) {
+        this.answerWith = answerWith;
+        this.publicId = publicId;
+    }
+
+    public InputSource answer(InvocationOnMock invocationOnMock) throws Throwable {
+        if (answerWith != null) {
+            log.info("Create input source for " + answerWith.toExternalForm());
+            InputSource result = new InputSource(answerWith.toExternalForm());
+            if (publicId != null) {
+                result.setPublicId(publicId);
+            }
+            return result;
+        } else {
+            String systemId = invocationOnMock.getArgument(1);
+            log.info("Create input source for " + systemId);
+            return new InputSource(systemId);
+        }
+    }
+
+}

--- a/jaxb-ri/xsom/src/test/java/com/sun/xml/xsom/parser/InputSourceMockAnswer.java
+++ b/jaxb-ri/xsom/src/test/java/com/sun/xml/xsom/parser/InputSourceMockAnswer.java
@@ -54,7 +54,7 @@ public class InputSourceMockAnswer implements Answer<InputSource> {
 
     private String publicId;
 
-    public InputSourceMockAnswer() {
+    private InputSourceMockAnswer() {
     }
 
     public InputSourceMockAnswer(URL answerWith) {

--- a/jaxb-ri/xsom/src/test/java/com/sun/xml/xsom/parser/LoggingErrorHandler.java
+++ b/jaxb-ri/xsom/src/test/java/com/sun/xml/xsom/parser/LoggingErrorHandler.java
@@ -1,0 +1,72 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package com.sun.xml.xsom.parser;
+
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import java.util.logging.Logger;
+
+public class LoggingErrorHandler implements ErrorHandler {
+
+    private Logger log = null;
+
+    public LoggingErrorHandler() {
+        this.log = Logger.getLogger(getClass().getName());
+    }
+
+    public LoggingErrorHandler(Object logOnBehalf) {
+        this.log = Logger.getLogger(logOnBehalf.getClass().getName());
+    }
+
+    public void warning(SAXParseException cause) throws SAXException {
+        log.warning("processed warning: " + cause.getMessage());
+    }
+
+    public void error(SAXParseException cause) throws SAXException {
+        log.warning("processed error: " + cause.getMessage());
+    }
+
+    public void fatalError(SAXParseException cause) throws SAXException {
+        log.severe("processed fatal: " + cause.getMessage());
+    }
+
+}

--- a/jaxb-ri/xsom/src/test/java/com/sun/xml/xsom/parser/XSOMParserMultiChameleonTest.java
+++ b/jaxb-ri/xsom/src/test/java/com/sun/xml/xsom/parser/XSOMParserMultiChameleonTest.java
@@ -1,0 +1,120 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package com.sun.xml.xsom.parser;
+
+import com.sun.xml.xsom.XSSchema;
+import com.sun.xml.xsom.XSSchemaSet;
+import org.junit.Test;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.SAXParserFactory;
+import java.net.URL;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class XSOMParserMultiChameleonTest {
+
+    static final String TNS_ONE = "urn:complex.one";
+    static final String TNS_TWO = "urn:complex.two";
+    static final String TNS_TOGETHER = "urn:complex.together";
+
+    // TODO specify javax.xml.parsers.SAXParserFactory=[xerces parser factory class name]
+
+    @Test
+    public void testRelativeImport() throws Exception {
+
+        final URL resourceChameleon = getClass().getResource("/multi-chameleon/chameleon.xsd");
+        final URL resourceOne = getClass().getResource("/multi-chameleon/One.xsd");
+        final URL resourceTwo = getClass().getResource("/multi-chameleon/Two.xsd");
+        final URL resourceTogether = getClass().getResource("/multi-chameleon/Together.xsd");
+
+        XSOMParser parser = new XSOMParser(SAXParserFactory.newInstance());
+        // set error handler
+        parser.setErrorHandler(new LoggingErrorHandler());
+
+        EntityResolver resolver = mock(EntityResolver.class);
+        parser.setEntityResolver(resolver);
+        when(resolver.resolveEntity((String) isNull(), eq("urn:common:chameleon.xsd"))).thenAnswer(new InputSourceMockAnswer(resourceChameleon));
+
+        parser.setEntityResolver(resolver);
+
+        // create input sources with resource url as systemId
+        parser.parse(new InputSource(resourceTogether.toExternalForm()));
+
+        // parser resolves the import internally
+        verify(resolver, times(2)).resolveEntity((String) isNull(), eq("urn:common:chameleon.xsd"));
+
+        // parser context tracks 7 documents of which 1 is an internal one and 3 are the same chameleon schema
+        // at different target namespace includes
+        assertEquals("Expected 7 schema files parsed", 7, parser.getDocuments().size());
+
+        XSSchemaSet schemaSet = parser.getResult();
+        assertEquals("Expected 4 full schemas parsed", 4, schemaSet.getSchemaSize());
+
+        // validate each one
+        for (SchemaDocument doc : parser.getDocuments()) {
+            XSSchema schema = doc.getSchema();
+            if (TNS_ONE.equals(doc.getTargetNamespace())) {
+                assertEquals(2, schema.getTypes().size());
+                assertEquals(1, schema.getSimpleTypes().size());
+                assertNotNull(schema.getSimpleType("SomeCommonType"));
+                assertEquals(1, schema.getComplexTypes().size());
+                assertNotNull(schema.getComplexType("EntityOne"));
+            } else if (TNS_TWO.equals(doc.getTargetNamespace())) {
+                // ONE one has 2 types in total
+                assertEquals(2, schema.getTypes().size());
+                assertEquals(1, schema.getSimpleTypes().size());
+                assertNotNull(schema.getSimpleType("SomeCommonType"));
+                assertEquals(1, schema.getComplexTypes().size());
+                assertNotNull(schema.getComplexType("EntityTwo"));
+            } else if (TNS_TOGETHER.equals(doc.getTargetNamespace())) {
+                // ONE one has 2 types in total
+                assertEquals(2, schema.getTypes().size());
+                assertEquals(1, schema.getSimpleTypes().size());
+                assertNotNull(schema.getSimpleType("SomeCommonType"));
+                assertEquals(1, schema.getComplexTypes().size());
+                assertNotNull(schema.getComplexType("Together"));
+            }
+        }
+    }
+
+}

--- a/jaxb-ri/xsom/src/test/java/com/sun/xml/xsom/parser/XSOMParserResolverTest.java
+++ b/jaxb-ri/xsom/src/test/java/com/sun/xml/xsom/parser/XSOMParserResolverTest.java
@@ -122,7 +122,7 @@ public class XSOMParserResolverTest {
         parser.setEntityResolver(resolver);
 
         // the first include is that using the systemId of resource One.xsd
-        when(resolver.resolveEntity((String) isNull(), eq(resourceOne.toExternalForm()))).thenAnswer(new InputSourceMockAnswer());
+        when(resolver.resolveEntity((String) isNull(), eq(resourceOne.toExternalForm()))).thenAnswer(new InputSourceMockAnswer(resourceOne));
 
         // create input sources with resource url as systemId
         parser.parse(new InputSource(resourceOne.toExternalForm()));
@@ -150,7 +150,7 @@ public class XSOMParserResolverTest {
         parser.setEntityResolver(resolver);
 
         // the first include is that using the systemId of resource One.xsd
-        when(resolver.resolveEntity((String) isNull(), eq(TNS_ONE + ":One.xsd"))).thenAnswer(new InputSourceMockAnswer());
+        when(resolver.resolveEntity((String) isNull(), eq(TNS_ONE + ":One.xsd"))).thenAnswer(new InputSourceMockAnswer(resourceOne));
 
         // create input sources with resource url as systemId
         parser.parse(new InputSource(resourceOne.toExternalForm()));

--- a/jaxb-ri/xsom/src/test/java/com/sun/xml/xsom/parser/XSOMParserResolverTest.java
+++ b/jaxb-ri/xsom/src/test/java/com/sun/xml/xsom/parser/XSOMParserResolverTest.java
@@ -1,0 +1,267 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package com.sun.xml.xsom.parser;
+
+import org.junit.Test;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.SAXParserFactory;
+import java.net.URL;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class XSOMParserResolverTest {
+
+    static final String TNS_ONE = "urn:complex.one";
+    static final String TNS_TWO = "urn:complex.two";
+
+    // TODO specify javax.xml.parsers.SAXParserFactory=[xerces parser factory class name]
+
+    @Test
+    public void testRelativeImport() throws Exception {
+
+        final URL resourceOne = getClass().getResource("/resolver/One.xsd");
+        final URL resourceTwo = getClass().getResource("/resolver/TwoRelativeImport.xsd");
+
+        XSOMParser parser = new XSOMParser(SAXParserFactory.newInstance());
+        // set error handler
+        parser.setErrorHandler(new LoggingErrorHandler());
+
+        EntityResolver resolver = mock(EntityResolver.class);
+        parser.setEntityResolver(resolver);
+
+        // create input sources with resource url as systemId
+        parser.parse(new InputSource(resourceOne.toExternalForm()));
+        validateSchemaSetOneOnly(parser.getDocuments());
+
+        parser.parse(new InputSource(resourceTwo.toExternalForm()));
+        validateSchemaSetImports(parser.getDocuments());
+
+        // parser resolves the import internally
+        verify(resolver, never()).resolveEntity((String) isNull(), anyString());
+
+    }
+
+    @Test
+    public void testResolverImport() throws Exception {
+
+        final URL resourceOne = getClass().getResource("/resolver/One.xsd");
+        final URL resourceTwo = getClass().getResource("/resolver/TwoResolverImport.xsd");
+
+        XSOMParser parser = new XSOMParser(SAXParserFactory.newInstance());
+        // set error handler
+        parser.setErrorHandler(new LoggingErrorHandler());
+
+        EntityResolver resolver = mock(EntityResolver.class);
+        parser.setEntityResolver(resolver);
+        when(resolver.resolveEntity(eq(TNS_ONE), eq(TNS_ONE + ":One.xsd"))).thenAnswer(new InputSourceMockAnswer(resourceOne));
+
+        // create input sources with resource url as systemId
+        parser.parse(new InputSource(resourceOne.toExternalForm()));
+        validateSchemaSetOneOnly(parser.getDocuments());
+
+        parser.parse(new InputSource(resourceTwo.toExternalForm()));
+        validateSchemaSetImports(parser.getDocuments());
+
+        // parser would have had to delegate to the entity resolver to get an answer for urn:complex.one:One.xsd
+        verify(resolver, times(1)).resolveEntity(eq(TNS_ONE), eq(TNS_ONE + ":One.xsd"));
+
+    }
+
+    @Test
+    public void testRelativeInclude() throws Exception {
+
+        final URL resourceOne = getClass().getResource("/resolver/One.xsd");
+        final URL resourceTwo = getClass().getResource("/resolver/TwoRelativeInclude.xsd");
+
+        XSOMParser parser = new XSOMParser(SAXParserFactory.newInstance());
+        // set error handler
+        parser.setErrorHandler(new LoggingErrorHandler());
+
+        EntityResolver resolver = mock(EntityResolver.class);
+        parser.setEntityResolver(resolver);
+
+        // the first include is that using the systemId of resource One.xsd
+        when(resolver.resolveEntity((String) isNull(), eq(resourceOne.toExternalForm()))).thenAnswer(new InputSourceMockAnswer());
+
+        // create input sources with resource url as systemId
+        parser.parse(new InputSource(resourceOne.toExternalForm()));
+        validateSchemaSetOneOnly(parser.getDocuments());
+
+        parser.parse(new InputSource(resourceTwo.toExternalForm()));
+        validateSchemaSetIncludes(parser.getDocuments());
+
+        // parser resolves the import internally
+        verify(resolver, times(1)).resolveEntity((String) isNull(), eq(resourceOne.toExternalForm()));
+
+    }
+
+    @Test
+    public void testResolverInclude() throws Exception {
+
+        final URL resourceOne = getClass().getResource("/resolver/One.xsd");
+        final URL resourceTwo = getClass().getResource("/resolver/TwoResolverInclude.xsd");
+
+        XSOMParser parser = new XSOMParser(SAXParserFactory.newInstance());
+        // set error handler
+        parser.setErrorHandler(new LoggingErrorHandler());
+
+        EntityResolver resolver = mock(EntityResolver.class);
+        parser.setEntityResolver(resolver);
+
+        // the first include is that using the systemId of resource One.xsd
+        when(resolver.resolveEntity((String) isNull(), eq(TNS_ONE + ":One.xsd"))).thenAnswer(new InputSourceMockAnswer());
+
+        // create input sources with resource url as systemId
+        parser.parse(new InputSource(resourceOne.toExternalForm()));
+        validateSchemaSetOneOnly(parser.getDocuments());
+
+        parser.parse(new InputSource(resourceTwo.toExternalForm()));
+        validateSchemaSetIncludes(parser.getDocuments());
+
+        // parser will first try to do a publicId lookup
+        verify(resolver, times(1)).resolveEntity(eq(TNS_ONE + ":One.xsd"), (String) isNull());
+
+        // parser then resolves with schemaLocation
+        verify(resolver, times(1)).resolveEntity((String) isNull(), eq(TNS_ONE + ":One.xsd"));
+
+    }
+
+    @Test
+    public void testResolverIncludePublicId() throws Exception {
+
+        final URL resourceOne = getClass().getResource("/resolver/One.xsd");
+        final URL resourceTwo = getClass().getResource("/resolver/TwoResolverInclude.xsd");
+
+        XSOMParser parser = new XSOMParser(SAXParserFactory.newInstance());
+        // set error handler
+        parser.setErrorHandler(new LoggingErrorHandler());
+
+        EntityResolver resolver = mock(EntityResolver.class);
+        parser.setEntityResolver(resolver);
+
+        // the first include is that using the systemId of resource One.xsd
+        when(resolver.resolveEntity(eq(TNS_ONE + ":One.xsd"), (String) isNull())).thenAnswer(new InputSourceMockAnswer(TNS_ONE + ":One.xsd", resourceOne));
+
+        // create input sources with resource url as systemId
+        parser.parse(new InputSource(resourceOne.toExternalForm()));
+        validateSchemaSetOneOnly(parser.getDocuments());
+
+        parser.parse(new InputSource(resourceTwo.toExternalForm()));
+        validateSchemaSetIncludes(parser.getDocuments());
+
+        // parser resolves the import internally
+        verify(resolver, times(1)).resolveEntity(eq(TNS_ONE + ":One.xsd"), (String) isNull());
+
+    }
+
+
+    private void validateSchemaSetOneOnly(Set<SchemaDocument> documents) {
+        assertEquals(2, documents.size());
+        boolean foundOneSchema = false;
+        for (SchemaDocument schema : documents) {
+            if (TNS_ONE.equals(schema.getSchema().getTargetNamespace())) {
+                validateSchemaOne(schema);
+                foundOneSchema = true;
+            }
+        }
+        assertTrue("schema set for One.xsd was not found in parser", foundOneSchema);
+    }
+
+    private void validateSchemaSetImports(Set<SchemaDocument> documents) {
+        assertEquals(3, documents.size());
+        boolean foundOneSchema = false;
+        boolean foundTwoSchema = false;
+        for (SchemaDocument schema : documents) {
+            if (TNS_ONE.equals(schema.getSchema().getTargetNamespace())) {
+                validateSchemaOne(schema);
+                foundOneSchema = true;
+            } else if (TNS_TWO.equals(schema.getSchema().getTargetNamespace())) {
+                validateSchemaTwo(schema);
+                foundTwoSchema = true;
+            }
+        }
+        assertTrue("schema set for One.xsd was not found in parser", foundOneSchema);
+        assertTrue("schema set for Two.xsd was not found in parser", foundTwoSchema);
+    }
+
+    private void validateSchemaSetIncludes(Set<SchemaDocument> documents) {
+        assertEquals(3, documents.size());
+        boolean foundOneSchema = false;
+        for (SchemaDocument schema : documents) {
+            if (TNS_ONE.equals(schema.getSchema().getTargetNamespace())) {
+                validateSchemaIncludes(schema);
+                foundOneSchema = true;
+            }
+        }
+        assertTrue("schema set for One.xsd was not found in parser", foundOneSchema);
+    }
+
+    private void validateSchemaOne(SchemaDocument schema) {
+        assertEquals("Expecting only 2 type definitions", 2, schema.getSchema().getTypes().size());
+        assertNotNull(schema.getSchema().getSimpleType("SomeReusableOne"));
+        assertNotNull(schema.getSchema().getComplexType("EntityOne"));
+        assertEquals("Expecting only 1 entity definitions", 1, schema.getSchema().getElementDecls().size());
+        assertNotNull(schema.getSchema().getElementDecl("EntityOne"));
+    }
+
+    private void validateSchemaTwo(SchemaDocument schema) {
+        assertEquals("Expecting only 2 type definitions", 2, schema.getSchema().getTypes().size());
+        assertNotNull(schema.getSchema().getSimpleType("SomeReusableTwo"));
+        assertNotNull(schema.getSchema().getComplexType("EntityTwo"));
+        assertEquals("Expecting only 1 entity definitions", 1, schema.getSchema().getElementDecls().size());
+        assertNotNull(schema.getSchema().getElementDecl("EntityTwo"));
+    }
+
+    private void validateSchemaIncludes(SchemaDocument schema) {
+        assertEquals("Expecting only 4 type definitions", 4, schema.getSchema().getTypes().size());
+        assertNotNull(schema.getSchema().getSimpleType("SomeReusableOne"));
+        assertNotNull(schema.getSchema().getSimpleType("SomeReusableTwo"));
+        assertNotNull(schema.getSchema().getComplexType("EntityOne"));
+        assertNotNull(schema.getSchema().getComplexType("EntityTwo"));
+        assertEquals("Expecting only 2 entity definitions", 2, schema.getSchema().getElementDecls().size());
+        assertNotNull(schema.getSchema().getElementDecl("EntityOne"));
+        assertNotNull(schema.getSchema().getElementDecl("EntityTwo"));
+    }
+
+}

--- a/jaxb-ri/xsom/src/test/resources/multi-chameleon/One.xsd
+++ b/jaxb-ri/xsom/src/test/resources/multi-chameleon/One.xsd
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://oss.oracle.com/licenses/CDDL+GPL-1.1
+    or LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+
+<xsd:schema xmlns="urn:complex.one"
+            targetNamespace="urn:complex.one"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="urn:complex.one"
+            elementFormDefault="qualified">
+
+  <xsd:include schemaLocation="chameleon.xsd"/>
+
+  <xsd:element name="EntityOne" type="tns:EntityOne"/>
+
+  <xsd:complexType name="EntityOne">
+    <xsd:sequence>
+      <xsd:element name="Name" maxOccurs="5">
+        <xsd:simpleType>
+          <xsd:restriction base="tns:SomeCommonType">
+            <xsd:maxLength value="255"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/jaxb-ri/xsom/src/test/resources/multi-chameleon/Together.xsd
+++ b/jaxb-ri/xsom/src/test/resources/multi-chameleon/Together.xsd
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://oss.oracle.com/licenses/CDDL+GPL-1.1
+    or LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+
+<xsd:schema xmlns="urn:complex.together"
+            targetNamespace="urn:complex.together"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="urn:complex.together"
+            xmlns:one="urn:complex.one"
+            xmlns:two="urn:complex.two"
+            elementFormDefault="qualified">
+
+  <xsd:include schemaLocation="urn:common:chameleon.xsd"/>
+  <xsd:import namespace="urn:complex.one" schemaLocation="One.xsd"/>
+  <xsd:import namespace="urn:complex.two" schemaLocation="Two.xsd"/>
+
+  <xsd:element name="Together" type="tns:Together"/>
+
+  <xsd:complexType name="Together">
+    <xsd:sequence>
+      <xsd:element ref="one:EntityOne"/>
+      <xsd:element ref="two:EntityTwo"/>
+      <xsd:element name="Common" type="tns:SomeCommonType"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/jaxb-ri/xsom/src/test/resources/multi-chameleon/Two.xsd
+++ b/jaxb-ri/xsom/src/test/resources/multi-chameleon/Two.xsd
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://oss.oracle.com/licenses/CDDL+GPL-1.1
+    or LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+
+<xsd:schema xmlns="urn:complex.two"
+            targetNamespace="urn:complex.two"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="urn:complex.two"
+            elementFormDefault="qualified">
+
+  <xsd:include schemaLocation="urn:common:chameleon.xsd"/>
+
+  <xsd:element name="EntityTwo" type="tns:EntityTwo"/>
+
+  <xsd:complexType name="EntityTwo">
+    <xsd:sequence>
+      <xsd:element name="Name" maxOccurs="5">
+        <xsd:simpleType>
+          <xsd:restriction base="tns:SomeCommonType">
+            <xsd:maxLength value="255"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/jaxb-ri/xsom/src/test/resources/multi-chameleon/chameleon.xsd
+++ b/jaxb-ri/xsom/src/test/resources/multi-chameleon/chameleon.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://oss.oracle.com/licenses/CDDL+GPL-1.1
+    or LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+
+  <xsd:simpleType name="SomeCommonType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="REUSE_COMMON_ONE"/>
+      <xsd:enumeration value="REUSE_COMMON_TWO"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/jaxb-ri/xsom/src/test/resources/resolver/One.xsd
+++ b/jaxb-ri/xsom/src/test/resources/resolver/One.xsd
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://oss.oracle.com/licenses/CDDL+GPL-1.1
+    or LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+
+<xsd:schema xmlns="urn:complex.one"
+            targetNamespace="urn:resolver.one"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="urn:complex.one"
+            elementFormDefault="qualified">
+
+  <xsd:element name="EntityOne" type="tns:EntityOne"/>
+
+  <xsd:complexType name="EntityOne">
+    <xsd:sequence>
+      <xsd:element name="Name" minOccurs="1" maxOccurs="5">
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="255"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="SomeReusableOne">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="ONE_SHARED"/>
+      <xsd:enumeration value="ONE_SILLY"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/jaxb-ri/xsom/src/test/resources/resolver/One.xsd
+++ b/jaxb-ri/xsom/src/test/resources/resolver/One.xsd
@@ -42,7 +42,7 @@
 -->
 
 <xsd:schema xmlns="urn:complex.one"
-            targetNamespace="urn:resolver.one"
+            targetNamespace="urn:complex.one"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns:tns="urn:complex.one"
             elementFormDefault="qualified">

--- a/jaxb-ri/xsom/src/test/resources/resolver/TwoRelativeImport.xsd
+++ b/jaxb-ri/xsom/src/test/resources/resolver/TwoRelativeImport.xsd
@@ -42,7 +42,7 @@
 -->
 
 <xsd:schema xmlns="urn:complex.two"
-            targetNamespace="urn:resolver.two"
+            targetNamespace="urn:complex.two"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns:one="urn:complex.one"
             xmlns:tns="urn:complex.two"

--- a/jaxb-ri/xsom/src/test/resources/resolver/TwoRelativeImport.xsd
+++ b/jaxb-ri/xsom/src/test/resources/resolver/TwoRelativeImport.xsd
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://oss.oracle.com/licenses/CDDL+GPL-1.1
+    or LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+
+<xsd:schema xmlns="urn:complex.two"
+            targetNamespace="urn:resolver.two"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:one="urn:complex.one"
+            xmlns:tns="urn:complex.two"
+            elementFormDefault="qualified">
+
+  <xsd:import namespace="urn:complex.one" schemaLocation="One.xsd"/>
+
+  <xsd:element name="EntityTwo" type="tns:EntityTwo"/>
+
+  <xsd:complexType name="EntityTwo">
+    <xsd:sequence>
+      <xsd:element name="Name" type="xsd:string"/>
+      <xsd:element name="CompositeType" type="tns:SomeReusableTwo"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="SomeReusableTwo">
+    <xsd:restriction base="one:SomeReusableOne">
+      <xsd:enumeration value="TWO_SILLY"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/jaxb-ri/xsom/src/test/resources/resolver/TwoRelativeInclude.xsd
+++ b/jaxb-ri/xsom/src/test/resources/resolver/TwoRelativeInclude.xsd
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://oss.oracle.com/licenses/CDDL+GPL-1.1
+    or LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+
+<xsd:schema xmlns="urn:complex.one"
+            targetNamespace="urn:resolver.one"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="urn:complex.one"
+            elementFormDefault="qualified">
+
+  <xsd:include schemaLocation="One.xsd"/>
+
+  <xsd:element name="EntityTwo" type="tns:EntityTwo"/>
+
+  <xsd:complexType name="EntityTwo">
+    <xsd:sequence>
+      <xsd:element name="Name" type="xsd:string"/>
+      <xsd:element name="CompositeType" type="tns:SomeReusableTwo"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="SomeReusableTwo">
+    <xsd:restriction base="tns:SomeReusableOne">
+      <xsd:enumeration value="TWO_SILLY"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/jaxb-ri/xsom/src/test/resources/resolver/TwoRelativeInclude.xsd
+++ b/jaxb-ri/xsom/src/test/resources/resolver/TwoRelativeInclude.xsd
@@ -42,7 +42,7 @@
 -->
 
 <xsd:schema xmlns="urn:complex.one"
-            targetNamespace="urn:resolver.one"
+            targetNamespace="urn:complex.one"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns:tns="urn:complex.one"
             elementFormDefault="qualified">

--- a/jaxb-ri/xsom/src/test/resources/resolver/TwoResolverImport.xsd
+++ b/jaxb-ri/xsom/src/test/resources/resolver/TwoResolverImport.xsd
@@ -42,7 +42,7 @@
 -->
 
 <xsd:schema xmlns="urn:complex.two"
-            targetNamespace="urn:resolver.two"
+            targetNamespace="urn:complex.two"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns:one="urn:complex.one"
             xmlns:tns="urn:complex.two"

--- a/jaxb-ri/xsom/src/test/resources/resolver/TwoResolverImport.xsd
+++ b/jaxb-ri/xsom/src/test/resources/resolver/TwoResolverImport.xsd
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://oss.oracle.com/licenses/CDDL+GPL-1.1
+    or LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+
+<xsd:schema xmlns="urn:complex.two"
+            targetNamespace="urn:resolver.two"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:one="urn:complex.one"
+            xmlns:tns="urn:complex.two"
+            elementFormDefault="qualified">
+
+  <xsd:import namespace="urn:complex.one" schemaLocation="urn:complex.one:One.xsd"/>
+
+  <xsd:element name="EntityTwo" type="tns:EntityTwo"/>
+
+  <xsd:complexType name="EntityTwo">
+    <xsd:sequence>
+      <xsd:element name="Name" type="xsd:string"/>
+      <xsd:element name="CompositeType" type="tns:SomeReusableTwo"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="SomeReusableTwo">
+    <xsd:restriction base="one:SomeReusableOne">
+      <xsd:enumeration value="TWO_SILLY"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/jaxb-ri/xsom/src/test/resources/resolver/TwoResolverInclude.xsd
+++ b/jaxb-ri/xsom/src/test/resources/resolver/TwoResolverInclude.xsd
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://oss.oracle.com/licenses/CDDL+GPL-1.1
+    or LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+
+<xsd:schema xmlns="urn:complex.one"
+            targetNamespace="urn:resolver.one"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="urn:complex.one"
+            elementFormDefault="qualified">
+
+  <xsd:include schemaLocation="urn:complex.one:One.xsd"/>
+
+  <xsd:element name="EntityTwo" type="tns:EntityTwo"/>
+
+  <xsd:complexType name="EntityTwo">
+    <xsd:sequence>
+      <xsd:element name="Name" type="xsd:string"/>
+      <xsd:element name="CompositeType" type="tns:SomeReusableTwo"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="SomeReusableTwo">
+    <xsd:restriction base="tns:SomeReusableOne">
+      <xsd:enumeration value="TWO_SILLY"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/jaxb-ri/xsom/src/test/resources/resolver/TwoResolverInclude.xsd
+++ b/jaxb-ri/xsom/src/test/resources/resolver/TwoResolverInclude.xsd
@@ -42,7 +42,7 @@
 -->
 
 <xsd:schema xmlns="urn:complex.one"
-            targetNamespace="urn:resolver.one"
+            targetNamespace="urn:complex.one"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns:tns="urn:complex.one"
             elementFormDefault="qualified">


### PR DESCRIPTION
There are actually multiple issues with the XSOM parser. Commit 3cc973a is just the test case and commit adf8310 is a proposed fix that satisfies all test cases.

The issues are:
1. XSOM is unable to deal with entity resolvers that return publicId
2. XSOM fails to track a single chameleon schema that is included into different namespaces
3. XSOM is unable to track multiple schemata that all resolve to the same systemId but may be loaded differently due to xml catalog layout
4. XSOM fails with a NPE when an entity resolver returns an InputSource that contains only the publicId of the document