### PR TITLE
Fix (un)marshal bug #1135

### DIFF
--- a/jaxb-ri/runtime/impl/src/main/java/com/sun/xml/bind/v2/runtime/property/PropertyFactory.java
+++ b/jaxb-ri/runtime/impl/src/main/java/com/sun/xml/bind/v2/runtime/property/PropertyFactory.java
@@ -44,6 +44,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 
+import com.sun.xml.bind.v2.model.core.ClassInfo;
 import com.sun.xml.bind.v2.model.core.ID;
 import com.sun.xml.bind.v2.model.core.PropertyKind;
 import com.sun.xml.bind.v2.model.runtime.RuntimeAttributePropertyInfo;
@@ -151,6 +152,9 @@ public abstract class PropertyFactory {
 
         RuntimeTypeInfo rti = types.iterator().next();
         if(!(rti instanceof RuntimeNonElement)) return false;
+
+        //if hasSubClasses it's not a leaf and we can't optimize, see #1135
+        if (rti instanceof ClassInfo && ((ClassInfo) rti).hasSubClasses()) return false;
 
         if(info.id()==ID.IDREF)
             // IDREF is always handled as leaf -- Transducer maps IDREF String back to an object


### PR DESCRIPTION
i'm not sure if the hasSubClasses() is enough in all cases. 
perhaps there should be a general way to disable this optimization on demand/fallback (system-property).

it works in my case (see the reproducer project mentioned in the bug report).