### PR TITLE
Fixing error message for jaxb.index file contents

### DIFF
--- a/jaxb-ri/runtime/impl/src/main/resources/com/sun/xml/bind/v2/Messages.properties
+++ b/jaxb-ri/runtime/impl/src/main/resources/com/sun/xml/bind/v2/Messages.properties
@@ -40,7 +40,7 @@
 
 # Not concatenated with any other string (written on a separate line).
 ILLEGAL_ENTRY = \
-    illegal entry: "{0}", entries should be of the form "ClassName" or "OuterClass.InnerClass", not "ClassName.class" or "fully.qualified.ClassName"
+    illegal entry: "{0}", entries should be of the form "ClassName" or "OuterClass$InnerClass", not "ClassName.class" or "fully.qualified.ClassName"
 
 # {0} - class name, {1} - resource location e.g. error loading class "Foo" listed in foo/bar/jaxb.index, make sure that entries are accessable on CLASSPATH and of the form "ClassName" or "OuterClass.InnerClass", not "ClassName.class" or "fully.qualified.ClassName"
 ERROR_LOADING_CLASS = \


### PR DESCRIPTION
Problem:
---------
The error message thrown by jaxb seems to be incorrect if the inner class name in jaxb.index file has```.``` instead of ```$```.

 Exception:
----------
[javax.xml.bind.JAXBException: error loading class
--
"d.innerclass" listed in a/b/c/jaxb.index, make sure that entries
are accessable on CLASSPATH and of the form "ClassName" or
"OuterClass.InnerClass", not "ClassName.class" or
"fully.qualified.ClassName"
- with linked exception:
[java.lang.ClassNotFoundException:

The message says to use OuterClass.InnerClass , however the correct format seems to be OuterClass$InnerClass. The separator for outclass.innerclass should be ```$```  and not ```.```

This change does not require build as this is error message change.

As this is my first commit, am not aware if anything else is required in this case.
Thanks in advance !

