### PR TITLE
Progress on JAXB RI modularization.

### DIFF
--- a/jaxb-ri/boms/bom-ext/pom.xml
+++ b/jaxb-ri/boms/bom-ext/pom.xml
@@ -63,7 +63,7 @@
     </description>
 
     <properties>
-        <dtd-parser.version>1.2</dtd-parser.version>
+        <dtd-parser.version>1.3-SNAPSHOT</dtd-parser.version>
         <ant.version>1.9.7</ant.version>
         <msv.version>2013.6.1</msv.version>
         <!-- don't forget to check if isorelax.version is valid -> used in osgi -->

--- a/jaxb-ri/boms/bom/pom.xml
+++ b/jaxb-ri/boms/bom/pom.xml
@@ -62,9 +62,9 @@
     <properties>
         <jaxb-api.version>2.3.1-b171012.0343</jaxb-api.version>
         <jaxb-api-osgi.version>2.3</jaxb-api-osgi.version>
-        <istack.version>3.0.5</istack.version>
-        <fastinfoset.version>1.2.13</fastinfoset.version>
-        <stax-ex.version>1.7.8</stax-ex.version>
+        <istack.version>3.0.6-SNAPSHOT</istack.version>
+        <fastinfoset.version>1.2.14-SNAPSHOT</fastinfoset.version>
+        <stax-ex.version>1.7.9-SNAPSHOT</stax-ex.version>
     </properties>
 
     <dependencyManagement>

--- a/jaxb-ri/bundles/ri/pom.xml
+++ b/jaxb-ri/bundles/ri/pom.xml
@@ -65,19 +65,71 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
+            <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-xjc</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
+            <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-jxc</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>codemodel</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>xsom</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind.external</groupId>
+            <artifactId>rngom</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.istack</groupId>
+            <artifactId>istack-commons-tools</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.istack</groupId>
+            <artifactId>istack-commons-runtime</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.dtd-parser</groupId>
+            <artifactId>dtd-parser</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>relaxngDatatype</groupId>
+            <artifactId>relaxngDatatype</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.staxex</groupId>
+            <artifactId>stax-ex</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.fastinfoset</groupId>
+            <artifactId>FastInfoset</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>txw2</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>

--- a/jaxb-ri/bundles/ri/src/main/assembly/assembly.xml
+++ b/jaxb-ri/bundles/ri/src/main/assembly/assembly.xml
@@ -97,11 +97,20 @@
             <fileMode>0644</fileMode>
             <includes>
                 <include>javax.xml.bind:jaxb-api</include>
-                <include>com.sun.xml.bind:jaxb-core</include>
-                <include>com.sun.xml.bind:jaxb-xjc</include>
-                <include>com.sun.xml.bind:jaxb-impl</include>
-                <include>com.sun.xml.bind:jaxb-jxc</include>
+                <include>org.glassfish.jaxb:jaxb-xjc</include>
+                <include>org.glassfish.jaxb:jaxb-runtime</include>
+                <include>org.glassfish.jaxb:jaxb-jxc</include>
                 <include>com.sun.xml.bind:jaxb-mod</include>
+                <include>org.glassfish.jaxb:codemodel</include>
+                <include>org.glassfish.jaxb:xsom</include>
+                <include>com.sun.xml.bind.external:rngom</include>
+                <include>com.sun.istack:istack-commons-runtime</include>
+                <include>com.sun.istack:istack-commons-tools</include>
+                <include>com.sun.xml.dtd-parser:dtd-parser</include>
+                <include>relaxngDatatype:relaxngDatatype</include>
+                <include>org.jvnet.staxex:stax-ex</include>
+                <include>com.sun.xml.fastinfoset:FastInfoset</include>
+                <include>org.glassfish.jaxb:txw2</include>
             </includes>
         </dependencySet>
         <dependencySet>

--- a/jaxb-ri/codemodel/codemodel/pom.xml
+++ b/jaxb-ri/codemodel/codemodel/pom.xml
@@ -70,4 +70,51 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>jdk9-setup</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-compile</id>
+                                <configuration>
+                                    <jdkToolchain>
+                                        <version>9</version>
+                                    </jdkToolchain>
+                                    <source>9</source>
+                                    <target>9</target>
+                                    <includes>
+                                        <include>module-info.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>base-compile</id>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <source>1.7</source>
+                                    <target>1.7</target>
+                                    <jdkToolchain>
+                                        <version>1.7</version>
+                                    </jdkToolchain>
+                                    <excludes>
+                                        <exclude>module-info.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/jaxb-ri/codemodel/codemodel/src/main/java/module-info.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/module-info.java
@@ -1,0 +1,52 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://oss.oracle.com/licenses/CDDL+GPL-1.1
+ * or LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+*/
+
+/**
+ * JAXB Library for code generation.
+ *
+ * @since 9
+ */
+module com.sun.codemodel {
+
+    exports com.sun.codemodel;
+    exports com.sun.codemodel.util;
+    exports com.sun.codemodel.writer;
+    exports com.sun.codemodel.fmt;
+}

--- a/jaxb-ri/external/rngom/pom.xml
+++ b/jaxb-ri/external/rngom/pom.xml
@@ -99,5 +99,56 @@
         </dependency>
                         
     </dependencies>
+    <profiles>
+        <profile>
+            <id>jdk9-setup</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-compile</id>
+                                <configuration>
+                                    <jdkToolchain>
+                                        <version>9</version>
+                                    </jdkToolchain>
+                                    <source>9</source>
+                                    <target>9</target>
+                                    <includes>
+                                        <include>module-info.java</include>
+                                    </includes>
+                                    <compilerArgs>
+                                        <arg>--add-reads</arg>
+                                        <arg>com.sun.tools.rngom=relaxngDatatype</arg>
+                                    </compilerArgs>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>base-compile</id>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <source>1.7</source>
+                                    <target>1.7</target>
+                                    <jdkToolchain>
+                                        <version>1.7</version>
+                                    </jdkToolchain>
+                                    <excludes>
+                                        <exclude>module-info.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>
 

--- a/jaxb-ri/external/rngom/src/main/java/module-info.java
+++ b/jaxb-ri/external/rngom/src/main/java/module-info.java
@@ -1,0 +1,59 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://oss.oracle.com/licenses/CDDL+GPL-1.1
+ * or LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+*/
+
+/**
+ *  RNGOM is a RelaxNG Object model library (XSOM for RelaxNG).
+ */
+module com.sun.tools.rngom {
+
+    requires java.xml;
+    requires relaxngDatatype;
+    requires java.logging;
+
+    exports org.kohsuke.rngom.parse;
+    exports org.kohsuke.rngom.parse.compact;
+    exports org.kohsuke.rngom.parse.xml;
+    exports org.kohsuke.rngom.digested;
+    exports org.kohsuke.rngom.nc;
+    exports org.kohsuke.rngom.xml.sax;
+    exports org.kohsuke.rngom.xml.util;
+    exports org.kohsuke.rngom.ast.builder;
+    exports org.kohsuke.rngom.ast.util;
+}

--- a/jaxb-ri/external/rngom/src/main/java/module-info.java
+++ b/jaxb-ri/external/rngom/src/main/java/module-info.java
@@ -44,7 +44,6 @@
 module com.sun.tools.rngom {
 
     requires java.xml;
-    requires relaxngDatatype;
     requires java.logging;
 
     exports org.kohsuke.rngom.parse;

--- a/jaxb-ri/jxc/pom.xml
+++ b/jaxb-ri/jxc/pom.xml
@@ -256,8 +256,6 @@
                             <forkCount>1</forkCount>
                             <reuseForks>true</reuseForks>
                             <argLine>
-                                --add-reads java.base=java.desktop
-                                --add-modules java.xml.bind
                                 --upgrade-module-path ${endorsed.dir}
                                 -Djdk.attach.allowAttachSelf
                            </argLine>

--- a/jaxb-ri/jxc/pom.xml
+++ b/jaxb-ri/jxc/pom.xml
@@ -221,13 +221,30 @@
                             <execution>
                                 <id>default-compile</id>
                                 <configuration>
-                                    <compilerArgs>
-                                        <arg>--add-modules</arg>
-                                        <arg>java.xml.bind</arg>
-                                        <arg>--upgrade-module-path</arg>
-                                        <arg>${endorsed.dir}</arg>
-                                    </compilerArgs>
-                                    <verbose>true</verbose>
+                                    <jdkToolchain>
+                                        <version>9</version>
+                                    </jdkToolchain>
+                                    <source>9</source>
+                                    <target>9</target>
+                                    <includes>
+                                        <include>module-info.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>base-compile</id>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <source>1.7</source>
+                                    <target>1.7</target>
+                                    <jdkToolchain>
+                                        <version>1.7</version>
+                                    </jdkToolchain>
+                                    <excludes>
+                                        <exclude>module-info.java</exclude>
+                                    </excludes>
                                 </configuration>
                             </execution>
                         </executions>

--- a/jaxb-ri/jxc/src/main/java/module-info.java
+++ b/jaxb-ri/jxc/src/main/java/module-info.java
@@ -1,0 +1,51 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://oss.oracle.com/licenses/CDDL+GPL-1.1
+ * or LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+*/
+
+/**
+ * JAXB schema generator.The *tool* to generate XML schema based on java classes.
+ */
+module com.sun.tools.jxc {
+
+    requires com.sun.xml.bind;
+
+
+    exports com.sun.tools.jxc;
+    exports com.sun.tools.jxc.api;
+}

--- a/jaxb-ri/runtime/impl/pom.xml
+++ b/jaxb-ri/runtime/impl/pom.xml
@@ -114,7 +114,7 @@
         <profile>
             <id>jdk9-setup</id>
             <activation>
-                <jdk>9</jdk>
+                <jdk>[9,)</jdk>
             </activation>
             <build>
                 <plugins>
@@ -137,24 +137,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                   <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>build-helper-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>add-jdk9-source</id>
-                                <phase>generate-sources</phase>
-                                <goals>
-                                    <goal>add-source</goal>
-                                </goals>
-                                <configuration>
-                                    <sources>
-                                        <source>src/main/jdk9</source>
-                                    </sources>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
@@ -162,12 +144,30 @@
                             <execution>
                                 <id>default-compile</id>
                                 <configuration>
-                                    <compilerArgs>
-                                        <arg>--add-modules</arg>
-                                        <arg>java.xml.bind</arg>
-                                        <arg>--upgrade-module-path</arg>
-                                        <arg>${endorsed.dir}</arg>
-                                    </compilerArgs>
+                                    <jdkToolchain>
+                                        <version>9</version>
+                                    </jdkToolchain>
+                                    <source>9</source>
+                                    <target>9</target>
+                                    <includes>
+                                        <include>module-info.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>base-compile</id>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <source>1.7</source>
+                                    <target>1.7</target>
+                                    <jdkToolchain>
+                                        <version>1.7</version>
+                                    </jdkToolchain>
+                                    <excludes>
+                                        <exclude>module-info.java</exclude>
+                                    </excludes>
                                 </configuration>
                             </execution>
                         </executions>

--- a/jaxb-ri/runtime/impl/src/main/java/module-info.java
+++ b/jaxb-ri/runtime/impl/src/main/java/module-info.java
@@ -38,10 +38,48 @@
  * holder.
 */
 
-module jaxb.txw2 {
+/**
+ * The XML Binding (JAXB) RI modularization implementation.
+ *
+ * @uses javax.xml.bind.JAXBContextFactory
+ *
+ */
+module com.sun.xml.bind {
+    requires java.xml.bind;
+    requires java.compiler;
+    requires java.desktop;
+    requires java.logging;
+
+    requires transitive java.activation;
     requires transitive java.xml;
 
-    exports com.sun.xml.txw2;
-    exports com.sun.xml.txw2.annotation;
-    exports com.sun.xml.txw2.output;
+    requires com.sun.xml.txw2;
+    requires com.sun.xml.fastinfoset;
+    requires org.jvnet.staxex;
+    requires com.sun.istack.runtime;
+
+    exports com.sun.xml.bind;
+    exports com.sun.xml.bind.annotation;
+    exports com.sun.xml.bind.api;
+    exports com.sun.xml.bind.api.impl;
+    exports com.sun.xml.bind.marshaller;
+    exports com.sun.xml.bind.unmarshaller;
+    exports com.sun.xml.bind.util;
+    exports com.sun.xml.bind.v2;
+    exports com.sun.xml.bind.v2.model.annotation;
+    exports com.sun.xml.bind.v2.model.core;
+    exports com.sun.xml.bind.v2.model.impl;
+    exports com.sun.xml.bind.v2.model.nav;
+    exports com.sun.xml.bind.v2.model.runtime;
+    exports com.sun.xml.bind.v2.model.util;
+    exports com.sun.xml.bind.v2.runtime;
+    exports com.sun.xml.bind.v2.runtime.unmarshaller;
+    exports com.sun.xml.bind.v2.schemagen;
+    exports com.sun.xml.bind.v2.schemagen.episode;
+    exports com.sun.xml.bind.v2.schemagen.xmlschema;
+    exports com.sun.xml.bind.v2.util;
+
+    opens com.sun.xml.bind.v2.model.nav to com.sun.tools.xjc;
+
+    uses javax.xml.bind.JAXBContextFactory;
 }

--- a/jaxb-ri/txw/runtime/pom.xml
+++ b/jaxb-ri/txw/runtime/pom.xml
@@ -88,23 +88,35 @@
             </activation>
             <build>
                 <plugins>
-                  <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>build-helper-maven-plugin</artifactId>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>add-jdk9-source</id>
-                                <phase>generate-sources</phase>
-                                <goals>
-                                    <goal>add-source</goal>
-                                </goals>
+                                <id>default-compile</id>
                                 <configuration>
-                                    <sources>
-                                        <source>src/main/jdk9</source>
-                                    </sources>
+                                    <jdkToolchain>
+                                        <version>9</version>
+                                    </jdkToolchain>
+                                    <source>9</source>
+                                    <target>9</target>
                                 </configuration>
                             </execution>
-                         </executions>
+                            <execution>
+                                <id>base-compile</id>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <jdkToolchain>
+                                        <version>1.7</version>
+                                    </jdkToolchain>
+                                    <excludes>
+                                        <exclude>module-info.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/jaxb-ri/txw/runtime/src/main/java/module-info.java
+++ b/jaxb-ri/txw/runtime/src/main/java/module-info.java
@@ -1,0 +1,47 @@
+/* 
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+ * 
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://oss.oracle.com/licenses/CDDL+GPL-1.1
+ * or LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ * 
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at LICENSE.txt.
+ * 
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ * 
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ * 
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a 
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+*/
+
+module com.sun.xml.txw2 {
+    requires transitive java.xml;
+
+    exports com.sun.xml.txw2;
+    exports com.sun.xml.txw2.annotation;
+    exports com.sun.xml.txw2.output;
+}

--- a/jaxb-ri/xjc/pom.xml
+++ b/jaxb-ri/xjc/pom.xml
@@ -275,6 +275,10 @@
                                     <includes>
                                         <include>module-info.java</include>
                                     </includes>
+                                    <compilerArgs>
+                                        <arg>--add-reads</arg>
+                                        <arg>com.sun.tools.xjc=antX</arg>
+                                    </compilerArgs>
                                 </configuration>
                             </execution>
                             <execution>

--- a/jaxb-ri/xjc/pom.xml
+++ b/jaxb-ri/xjc/pom.xml
@@ -267,12 +267,27 @@
                             <execution>
                                 <id>default-compile</id>
                                 <configuration>
-                                    <compilerArgs>
-                                        <arg>--add-modules</arg>
-                                        <arg>java.xml.bind</arg>
-                                        <arg>--upgrade-module-path</arg>
-                                        <arg>${endorsed.dir}</arg>
-                                    </compilerArgs>
+                                    <jdkToolchain>
+                                        <version>9</version>
+                                    </jdkToolchain>
+                                    <source>9</source>
+                                    <target>9</target>
+                                    <includes>
+                                        <include>module-info.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>base-compile</id>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <source>1.7</source>
+                                    <target>1.7</target>
+                                    <excludes>
+                                        <exclude>module-info.java</exclude>
+                                    </excludes>
                                 </configuration>
                             </execution>
                         </executions>

--- a/jaxb-ri/xjc/src/main/java/module-info.java
+++ b/jaxb-ri/xjc/src/main/java/module-info.java
@@ -1,0 +1,62 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://oss.oracle.com/licenses/CDDL+GPL-1.1
+ * or LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+*/
+
+/**
+ * JAXB Binding Compiler. Contains source code needed for binding customization files into java sources.
+ * In other words: the *tool* to generate java classes for the given xml representation.
+ */
+module com.sun.tools.xjc {
+
+    requires java.logging;
+    requires java.compiler;
+    requires java.desktop;
+
+    requires com.sun.codemodel;
+    requires java.xml.bind;
+    requires com.sun.xml.bind;
+    requires com.sun.istack.runtime;
+    requires com.sun.istack.tools;
+    requires com.sun.xml.xsom;
+    requires com.sun.tools.rngom;
+    requires com.sun.xml.dtdparser;
+    requires com.sun.xml.txw2;
+    requires ant;
+
+}

--- a/jaxb-ri/xjc/src/main/java/module-info.java
+++ b/jaxb-ri/xjc/src/main/java/module-info.java
@@ -57,6 +57,5 @@ module com.sun.tools.xjc {
     requires com.sun.tools.rngom;
     requires com.sun.xml.dtdparser;
     requires com.sun.xml.txw2;
-    requires ant;
 
 }

--- a/jaxb-ri/xsom/pom.xml
+++ b/jaxb-ri/xsom/pom.xml
@@ -182,5 +182,58 @@
                 <!--</plugins>-->
             <!--</build>-->
         <!--</profile>-->
+
+        <profile>
+            <id>jdk9-setup</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-compile</id>
+                                <configuration>
+                                    <jdkToolchain>
+                                        <version>9</version>
+                                    </jdkToolchain>
+                                    <source>9</source>
+                                    <target>9</target>
+                                    <includes>
+                                        <include>module-info.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>base-compile</id>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <source>1.7</source>
+                                    <target>1.7</target>
+                                    <jdkToolchain>
+                                        <version>1.7</version>
+                                    </jdkToolchain>
+                                    <excludes>
+                                        <exclude>module-info.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/jaxb-ri/xsom/pom.xml
+++ b/jaxb-ri/xsom/pom.xml
@@ -205,6 +205,10 @@
                                     <includes>
                                         <include>module-info.java</include>
                                     </includes>
+                                    <compilerArgs>
+                                        <arg>--add-reads</arg>
+                                        <arg>com.sun.tools.rngom=relaxngDatatype</arg>
+                                    </compilerArgs>
                                 </configuration>
                             </execution>
                             <execution>

--- a/jaxb-ri/xsom/src/main/java/module-info.java
+++ b/jaxb-ri/xsom/src/main/java/module-info.java
@@ -48,7 +48,6 @@ module com.sun.xml.xsom {
 
     requires java.xml;
     requires java.desktop;
-    requires relaxngDatatype;
     requires java.logging;
 
     exports com.sun.xml.xsom;

--- a/jaxb-ri/xsom/src/main/java/module-info.java
+++ b/jaxb-ri/xsom/src/main/java/module-info.java
@@ -1,8 +1,8 @@
-/* 
+/*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
  * and Distribution License("CDDL") (collectively, the "License").  You
@@ -11,25 +11,25 @@
  * https://oss.oracle.com/licenses/CDDL+GPL-1.1
  * or LICENSE.txt.  See the License for the specific
  * language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file at LICENSE.txt.
- * 
+ *
  * GPL Classpath Exception:
  * Oracle designates this particular file as subject to the "Classpath"
  * exception as provided by Oracle in the GPL Version 2 section of the License
  * file that accompanied this code.
- * 
+ *
  * Modifications:
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyright [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding "[Contributor]
  * elects to include this software in this distribution under the [CDDL or GPL
- * Version 2] license."  If you don't indicate a single choice of license, a 
+ * Version 2] license."  If you don't indicate a single choice of license, a
  * recipient has the option to distribute your version of this file under
  * either the CDDL, the GPL Version 2 or to extend the choice of license to
  * its licensees as provided above.  However, if you add GPL Version 2 code
@@ -39,50 +39,21 @@
 */
 
 /**
- * The XML Binding (JAXB) RI modularization implementation.
+ * XML Schema Object Model (XSOM) is a Java library that allows applications to easily parse XML Schema
+ * documents and inspect information in them. It is expected to be useful for applications that need to take XML
+ * Schema as an input.
  *
- * <p> This module is upgradeable.
- *
- * @uses javax.xml.bind.JAXBContextFactory
- *
- * @since 9
  */
-module java.xml.bind.imp {
-    requires java.xml.bind;
-    requires java.compiler;
+module com.sun.xml.xsom {
+
+    requires java.xml;
     requires java.desktop;
+    requires relaxngDatatype;
     requires java.logging;
-    requires jdk.unsupported;
 
-    requires transitive java.activation;
-    requires transitive java.xml;
-
-    requires jaxb.txw2;
-    requires FastInfoset;
-    requires stax.ex;
-    requires istack.commons.runtime;
-
-    exports com.sun.xml.bind;
-    exports com.sun.xml.bind.annotation;
-    exports com.sun.xml.bind.api;
-    exports com.sun.xml.bind.api.impl;
-    exports com.sun.xml.bind.marshaller;
-    exports com.sun.xml.bind.unmarshaller;
-    exports com.sun.xml.bind.util;
-    exports com.sun.xml.bind.v2;
-    exports com.sun.xml.bind.v2.model.annotation;
-    exports com.sun.xml.bind.v2.model.core;
-    exports com.sun.xml.bind.v2.model.impl;
-    exports com.sun.xml.bind.v2.model.nav;
-    opens com.sun.xml.bind.v2.model.nav;
-    exports com.sun.xml.bind.v2.model.runtime;
-    exports com.sun.xml.bind.v2.model.util;
-    exports com.sun.xml.bind.v2.runtime;
-    exports com.sun.xml.bind.v2.runtime.unmarshaller;
-    exports com.sun.xml.bind.v2.schemagen;
-    exports com.sun.xml.bind.v2.schemagen.episode;
-    exports com.sun.xml.bind.v2.schemagen.xmlschema;
-    exports com.sun.xml.bind.v2.util;
-
-    uses javax.xml.bind.JAXBContextFactory;
+    exports com.sun.xml.xsom;
+    exports com.sun.xml.xsom.util;
+    exports com.sun.xml.xsom.visitor;
+    exports com.sun.xml.xsom.impl.util;
+    exports com.sun.xml.xsom.parser;
 }


### PR DESCRIPTION
Everything is now loaded as native modules. I have created test clients running unzipped jaxb-ri as native modules.

Here is set of --list-modules for all dependencies of jaxb runtime, xjc and jxc.
                ant ant.jar automatic
                ant.launcher ant-launcher.jar automatic
                com.sun.codemodel codemodel.jar
                com.sun.istack.runtime istack-commons-runtime.jar
                com.sun.istack.tools istack-commons-tools.jar
                com.sun.tools.jxc jaxb-jxc.jar
                com.sun.tools.rngom rngom.jar
                com.sun.tools.xjc jaxb-xjc.jar
                com.sun.xml.bind jaxb-runtime.jar
                com.sun.xml.dtdparser dtd-parser.jar
                com.sun.xml.fastinfoset FastInfoset.jar
                com.sun.xml.txw2 txw2.jar
                com.sun.xml.xsom xsom.jar
                org.jvnet.staxex stax-ex.jar
                relaxngDatatype relaxngDatatype.jar automatic

So the only without module-info declaration left are relaxngDatatype (we don't own source), ant and ant.launcher.

After merge we should be able to run TCKs and load jaxb as native modules.