### PR TITLE
POM.XML shade mods for Jaxb 2 2 11 branch

### DIFF
--- a/jaxb-ri/boms/bom/pom.xml
+++ b/jaxb-ri/boms/bom/pom.xml
@@ -61,7 +61,7 @@
     <description>JAXB Bill of Materials (BOM)</description>
 
     <properties>
-        <jaxb-api.version>2.2.12-b140109.1041</jaxb-api.version>
+        <jaxb-api.version>2.2.12</jaxb-api.version>
         <istack.version>2.21</istack.version>
         <fastinfoset.version>1.2.13</fastinfoset.version>
         <stax-ex.version>1.7.7</stax-ex.version>

--- a/jaxb-ri/docs/release-documentation/src/docbook/jaxb-2-0-changelog.xml
+++ b/jaxb-ri/docs/release-documentation/src/docbook/jaxb-2-0-changelog.xml
@@ -131,7 +131,7 @@ holder.
                 </programlisting>
             </para></listitem>
             <listitem><para>
-                From now JAXB RI project uses GIT SVC. You can get our sources from:
+                From now JAXB RI project uses GIT VCS. You can get our sources from:
                 <programlisting>
                     Java.net:   git clone git://java.net/jaxb~v2
                     GitHub:     git clone https://github.com/gf-metro/jaxb.git

--- a/jaxb-ri/docs/release-documentation/src/docbook/jaxb-2-0-changelog.xml
+++ b/jaxb-ri/docs/release-documentation/src/docbook/jaxb-2-0-changelog.xml
@@ -77,7 +77,10 @@ holder.
                         <link xlink:href="https://java.net/jira/browse/JAXB-973">JAXB-973</link>: generated code should be
                         compilable with <literal>'-Xdoclint:all'</literal>
                     </para></listitem>
-                    <listitem><para>XJC generates ordered ObjectFactories, <literal>@XmlSeeAlso</literal> annotations and episode files</para></listitem>
+                    <listitem><para>
+                        <link xlink:href="https://java.net/jira/browse/JAXB-598">JAXB-598</link>: XJC generates ordered
+                        ObjectFactories, <literal>@XmlSeeAlso</literal> annotations and episode files.
+                    </para></listitem>
                 </itemizedlist>
             </para></listitem>
         </itemizedlist>
@@ -127,6 +130,7 @@ holder.
                         &lt;groupId&gt;org.glassfish.jaxb&lt;/groupId&gt;
                         &lt;artifactId&gt;jaxb-bom&lt;/artifactId&gt;
                         &lt;version&gt;2.2.8&lt;/version&gt;
+                        &lt;type&gt;pom&lt;/type&gt;
                     &lt;/dependency&gt;
                 </programlisting>
             </para></listitem>

--- a/jaxb-ri/docs/www/src/main/resources/index.html
+++ b/jaxb-ri/docs/www/src/main/resources/index.html
@@ -16,8 +16,8 @@
 
 <h4 style="clear:left;">Release Notes</h4>
 <p>
-  <a href="/nonav/${jaxb.version}/docs/">Browse the release notes online</a>,
-  including <a href="/nonav/${jaxb.version}/docs/release-documentation.html#jaxb-2-0-release-notes">what's new</a>.
+  <a href="/nonav/${version}/docs/">Browse the release notes online</a>,
+  including <a href="/nonav/${version}/docs/release-documentation.html#jaxb-2-0-release-notes">what's new</a>.
 </p>
 
 <h4 style="clear:left;">Technical Support</h4>

--- a/jaxb-ri/pom.xml
+++ b/jaxb-ri/pom.xml
@@ -445,7 +445,7 @@ holder.
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>gfnexus-maven-plugin</artifactId>
-                    <version>0.18</version>
+                    <version>0.20</version>
                     <configuration>
                         <stagingRepos>
                             <stagingRepo>


### PR DESCRIPTION
POM.XML shade mods
[xjc.zip](https://github.com/javaee/jaxb-v2/files/1701459/xjc.zip)

