### PR TITLE
Use TLS for repository access

### DIFF
--- a/jaxb-ri/pom.xml
+++ b/jaxb-ri/pom.xml
@@ -115,38 +115,30 @@
     <repositories>
         <repository>
             <id>releases.java.net</id>
-            <url>http://maven.java.net/content/repositories/releases/</url>
+            <url>https://maven.java.net/content/repositories/releases/</url>
             <layout>default</layout>
         </repository>
         <repository>
             <id>shapshots.java.net</id>
-            <url>http://maven.java.net/content/repositories/snapshots/</url>
+            <url>https://maven.java.net/content/repositories/snapshots/</url>
             <layout>default</layout>
         </repository>
         <repository>
             <id>jvnet-nexus-staging</id>
-            <url>http://maven.java.net/content/repositories/staging/</url>
+            <url>https://maven.java.net/content/repositories/staging/</url>
             <layout>default</layout>
-        </repository>
-        <repository>
-            <id>netbeans</id>
-            <name>Repository hosting NetBeans modules</name>
-            <url>http://bits.netbeans.org/nexus/content/groups/netbeans</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>releases.java.net</id>
-            <url>http://maven.java.net/content/repositories/releases/</url>
+            <url>https://maven.java.net/content/repositories/releases/</url>
             <layout>default</layout>
         </pluginRepository>
         <pluginRepository>
             <id>jvnet-nexus-staging</id>
-            <url>http://maven.java.net/content/repositories/staging/</url>
+            <url>https://maven.java.net/content/repositories/staging/</url>
             <layout>default</layout>
         </pluginRepository>
     </pluginRepositories>


### PR DESCRIPTION
While doing research for an downstream project I found out that jaxb uses insecure URLs. Proposing to change these URLs to TLS for security reasons. Since there might be users interested in having these changes propagated for other releases I ask you to merge these to other maintained branches as well.

As an only related change I removed the dysfunctional netbeans repo.