### PR TITLE
Update shell scripts to use module path.

### DIFF
--- a/jaxb-ri/boms/bom/pom.xml
+++ b/jaxb-ri/boms/bom/pom.xml
@@ -223,7 +223,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
+            <dependency>
+                <groupId>com.sun.activation</groupId>
+                <artifactId>javax.activation</artifactId>
+                <version>1.2.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/jaxb-ri/bundles/ri/pom.xml
+++ b/jaxb-ri/bundles/ri/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2013-2017 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013-2018 Oracle and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -144,6 +144,11 @@
             <artifactId>jaxb-samples</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>javax.activation</artifactId>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/jaxb-ri/bundles/ri/src/main/assembly/assembly.xml
+++ b/jaxb-ri/bundles/ri/src/main/assembly/assembly.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2013-2017 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013-2018 Oracle and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -109,6 +109,7 @@
                 <include>org.jvnet.staxex:stax-ex</include>
                 <include>com.sun.xml.fastinfoset:FastInfoset</include>
                 <include>org.glassfish.jaxb:txw2</include>
+                <include>com.sun.activation:javax.activation</include>
             </includes>
             <excludes>
                 <exclude>org.apache.ant:ant</exclude>
@@ -124,8 +125,10 @@
             <fileMode>0644</fileMode>
             <includes>
                 <include>relaxngDatatype:relaxngDatatype</include>
-                <include>org.apache.ant:ant</include>
             </includes>
+            <excludes>
+                <exclude>org.apache.ant:ant</exclude>
+            </excludes>
         </dependencySet>
         <dependencySet>
             <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>

--- a/jaxb-ri/jxc/pom.xml
+++ b/jaxb-ri/jxc/pom.xml
@@ -185,6 +185,9 @@
                         </goals>
                         <configuration>
                             <archive>
+                                <manifestEntries>
+                                    <Multi-Release>true</Multi-Release>
+                                </manifestEntries>
                                 <manifest>
                                     <mainClass>com.sun.tools.jxc.SchemaGeneratorFacade</mainClass>
                                 </manifest>

--- a/jaxb-ri/jxc/src/main/java/com/sun/tools/jxc/ap/AnnotationParser.java
+++ b/jaxb-ri/jxc/src/main/java/com/sun/tools/jxc/ap/AnnotationParser.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -152,9 +152,6 @@ public final class AnnotationParser extends AbstractProcessor {
 
     @Override
     public SourceVersion getSupportedSourceVersion() {
-        if (SourceVersion.latest().compareTo(SourceVersion.RELEASE_6) > 0)
-            return SourceVersion.valueOf("RELEASE_7");
-        else
-            return SourceVersion.RELEASE_6;
+        return SourceVersion.latestSupported();
     }
 }

--- a/jaxb-ri/jxc/src/main/java/com/sun/tools/jxc/ap/SchemaGenerator.java
+++ b/jaxb-ri/jxc/src/main/java/com/sun/tools/jxc/ap/SchemaGenerator.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -163,9 +163,6 @@ public class SchemaGenerator extends AbstractProcessor {
 
     @Override
     public SourceVersion getSupportedSourceVersion() {
-        if (SourceVersion.latest().compareTo(SourceVersion.RELEASE_6) > 0)
-            return SourceVersion.valueOf("RELEASE_7");
-        else
-            return SourceVersion.RELEASE_6;
+        return SourceVersion.latestSupported();
     }
 }

--- a/jaxb-ri/runtime/impl/pom.xml
+++ b/jaxb-ri/runtime/impl/pom.xml
@@ -90,6 +90,10 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>javax.activation</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jaxb-ri/xjc/pom.xml
+++ b/jaxb-ri/xjc/pom.xml
@@ -235,6 +235,9 @@
                         </goals>
                         <configuration>
                             <archive>
+                                <manifestEntries>
+                                    <Multi-Release>true</Multi-Release>
+                                </manifestEntries>
                                 <manifest>
                                     <mainClass>com.sun.tools.xjc.XJCFacade</mainClass>
                                 </manifest>

--- a/jaxb-ri/xsom/src/main/java/module-info.java
+++ b/jaxb-ri/xsom/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2018 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -49,6 +49,14 @@ module com.sun.xml.xsom {
     requires java.xml;
     requires java.desktop;
     requires java.logging;
+
+    /**
+    * TODO work around and remove dependency. This is automatic module name,
+    * without descriptor or even MANIFEST hint. This dependency was historically extracted from
+    * https://github.com/relaxng/jing-trang/tree/master/mod/datatype/src/main/org/relaxng/datatype
+    * and may cause split package when loaded together with original jing/trang
+    **/
+    requires relaxngDatatype;
 
     exports com.sun.xml.xsom;
     exports com.sun.xml.xsom.util;


### PR DESCRIPTION
Added dependency to javax.annotation (fix for jdk without java.xml.bind module).

Signed-off-by: Roman Grigoriadi <roman.grigoriadi@oracle.com>