### PR TITLE
Add support for nonProxyHosts

### DIFF
--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/Options.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/Options.java
@@ -243,6 +243,7 @@ public class Options {
     // Proxy setting.
     private String proxyHost = null;
     private String proxyPort = null;
+    private String nonProxyHosts = null;
     public String proxyAuth = null;
 
     /**
@@ -681,6 +682,10 @@ public class Options {
             proxyPort = requireArgument("-port", args, ++i);
             return 2;
         }
+        if (args[i].equals("-nonProxyHosts")){
+            nonProxyHosts = requireArgument("-nonProxyHosts", args, ++i);
+            return 2;
+        }
         if (args[i].equals("-catalog")) {
             // use Sun's "XML Entity and URI Resolvers" by Norman Walsh
             // to resolve external entities.
@@ -883,6 +888,9 @@ public class Options {
             }
             if (proxyAuth != null) {
                 DefaultAuthenticator.getAuthenticator().setProxyAuth(proxyAuth);
+            }
+            if(nonProxyHosts != null){
+                System.setProperty("http.nonProxyHosts", nonProxyHosts);
             }
         }
 

--- a/jaxb-ri/xjc/src/test/java/com/sun/tools/xjc/OptionsJUTest.java
+++ b/jaxb-ri/xjc/src/test/java/com/sun/tools/xjc/OptionsJUTest.java
@@ -137,6 +137,7 @@ public class OptionsJUTest extends TestCase {
             opts.parseArguments(new String[]{"-httpproxy", "www.proxy", grammar.getAbsolutePath()});
             assertEquals("www.proxy", getField("proxyHost", opts));
             assertEquals("80", getField("proxyPort", opts));
+            assertNull(getField("nonProxyHosts", opts));
             assertNull(opts.proxyAuth);
         } catch (BadCommandLineException ex) {
             Logger.getLogger(OptionsJUTest.class.getName()).log(Level.SEVERE, null, ex);
@@ -151,6 +152,22 @@ public class OptionsJUTest extends TestCase {
             opts.parseArguments(new String[]{"-httpproxy", "www.proxy1:4321", grammar.getAbsolutePath()});
             assertEquals("www.proxy1", getField("proxyHost", opts));
             assertEquals("4321", getField("proxyPort", opts));
+            assertNull(getField("nonProxyHosts", opts));
+            assertNull(opts.proxyAuth);
+        } catch (BadCommandLineException ex) {
+            Logger.getLogger(OptionsJUTest.class.getName()).log(Level.SEVERE, null, ex);
+            fail();
+        } finally {
+            if (opts.proxyAuth != null) {
+                DefaultAuthenticator.reset();
+            }
+        }
+        opts = new Options();
+        try {
+            opts.parseArguments(new String[]{"-httpproxy", "www.proxy2:4321", "-nonProxyHosts", "localhost|*.example.com", grammar.getAbsolutePath()});
+            assertEquals("www.proxy2", getField("proxyHost", opts));
+            assertEquals("4321", getField("proxyPort", opts));
+            assertEquals("localhost|*.example.com",getField("nonProxyHosts", opts));
             assertNull(opts.proxyAuth);
         } catch (BadCommandLineException ex) {
             Logger.getLogger(OptionsJUTest.class.getName()).log(Level.SEVERE, null, ex);
@@ -165,6 +182,7 @@ public class OptionsJUTest extends TestCase {
             opts.parseArguments(new String[]{"-httpproxy", "user:pwd@www.proxy3:7890", grammar.getAbsolutePath()});
             assertEquals("www.proxy3", getField("proxyHost", opts));
             assertEquals("7890", getField("proxyPort", opts));
+            assertNull(getField("nonProxyHosts", opts));
             assertEquals("user:pwd", opts.proxyAuth);
         } catch (BadCommandLineException ex) {
             Logger.getLogger(OptionsJUTest.class.getName()).log(Level.SEVERE, null, ex);
@@ -179,6 +197,7 @@ public class OptionsJUTest extends TestCase {
             opts.parseArguments(new String[]{"-httpproxy", "duke:s@cr@t@proxy98", grammar.getAbsolutePath()});
             assertEquals("proxy98", getField("proxyHost", opts));
             assertEquals("80", getField("proxyPort", opts));
+            assertNull(getField("nonProxyHosts", opts));
             assertEquals("duke:s@cr@t", opts.proxyAuth);
         } catch (BadCommandLineException ex) {
             Logger.getLogger(OptionsJUTest.class.getName()).log(Level.SEVERE, null, ex);


### PR DESCRIPTION
It seems the proxy settings can be set when it comes to host, port and authentication. But the nonProxyHosts is not implemented yet.
This pull request should be able to solve that problem.