### PR TITLE
Prevent NPE in JAnnotationUse.getAnnotationMembers()

### DIFF
--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JAnnotationUse.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JAnnotationUse.java
@@ -75,7 +75,9 @@ public final class JAnnotationUse extends JAnnotationValue {
     }
 
     public Map<String, JAnnotationValue> getAnnotationMembers() {
-        return Collections.unmodifiableMap(memberValues);
+        return memberValues == null 
+            ? Collections.emptyMap()
+            : Collections.unmodifiableMap(memberValues);
     }
     
     private JCodeModel owner() {


### PR DESCRIPTION
There's a NPE possible in `JAnnotationUse.getAnnotationMembers()`:

```java
Caused by: java.lang.NullPointerException
    at java.util.Collections$UnmodifiableMap.<init> (Collections.java:1442)
    at java.util.Collections.unmodifiableMap (Collections.java:1429)
    at com.sun.codemodel.JAnnotationUse.getAnnotationMembers (JAnnotationUse.java:78)
```

I've just signed and emailed the OCA