### PR TITLE
[nobug]: osgi bundle should require at least javase 8

### DIFF
--- a/jaxb-ri/bundles/osgi/osgi/pom.xml
+++ b/jaxb-ri/bundles/osgi/osgi/pom.xml
@@ -299,6 +299,7 @@
                         </goals>
                         <configuration>
                             <instructions>
+                                <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version>=1.8))"</Require-Capability>
                                 <Export-Package>
                                     com.sun.codemodel;version=${jaxb.osgiVersion},
                                     com.sun.codemodel.*;version=${jaxb.osgiVersion},


### PR DESCRIPTION
jaxb-osgi is supposed to run on JDK8

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>